### PR TITLE
fix decodeCheck().value

### DIFF
--- a/src/check.js
+++ b/src/check.js
@@ -7,7 +7,7 @@ import {coinToBuffer, bufferToCoin} from 'minterjs-tx';
 import {convertToPip, convertFromPip, mPrefixStrip} from 'minterjs-util';
 // import {convertToPip, convertFromPip} from 'minterjs-util/src/converter.js';
 // import {mPrefixStrip} from 'minterjs-util/src/prefix.js';
-import {isNumericInteger, integerToHexString, bufferToInteger} from './utils.js';
+import {isNumericInteger, integerToHexString, bufferToInteger, bufferToBigInteger} from './utils.js';
 
 class Check {
     constructor(data) {
@@ -159,7 +159,7 @@ export function decodeCheck(rawCheck) {
         nonce: check.nonce.toString('utf-8'),
         chainId: bufferToInteger(check.chainId),
         coin: bufferToCoin(check.coin),
-        value: convertFromPip(bufferToInteger(check.value)),
+        value: convertFromPip(bufferToBigInteger(check.value)),
         dueBlock: bufferToInteger(check.dueBlock),
     };
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,6 +35,10 @@ export function bufferToInteger(buf) {
     return parseInt(buf.toString('hex'), 16) || 0;
 }
 
+export function bufferToBigInteger(buf) {
+    return BigInt('0x'+buf.toString('hex')) || 0;
+}
+
 export const toHexString = integerToHexString;
 
 export function addTxDataFields(txData) {


### PR DESCRIPTION
fix decodeCheck().value; Issue #16

```
const decodeCheck = require('minter-js-sdk').decodeCheck
check = Buffer.from('f8b18631323331323301843b9ac9ff8a42495000000000000000920169d38af788b84ed70bc438cf31f84ff3b4b841946d1dc72c2dcf9008b7ab3e79ad787879911cb7f0b34765ccfd6b5aace5ec2c59112c19f4ac331d4d50e313d27354cc4dad3c32be7c61a1596504024c98a462011ca0838202ed4b9fbce363f1da4f7ea6b7368bbef43290c370d1aaaf2860ca2a68cca078d0640734e53b7e43292a5e7fd01a4d90327988fe9eb26057c5b038d7173544', 'hex');

```
Before fix:
`decodeCheck(check).value = '123123123123123120000000'`
After fix:
`decodeCheck(check).value = '123123123123123123123123.123123123123123124'`