### PR TITLE
Fixes babel import error in compiled module

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "homepage": "https://github.com/MinterTeam/minter-js-sdk#readme",
   "dependencies": {
+    "@babel/runtime": "^7.11.2",
     "axios": "^0.20.0",
     "base64-js": "^1.3.1",
     "big.js": "^6.0.1",
@@ -70,7 +71,6 @@
     "@babel/core": "^7.11.6",
     "@babel/plugin-transform-runtime": "^7.11.5",
     "@babel/preset-env": "^7.11.5",
-    "@babel/runtime": "^7.11.2",
     "@rollup/plugin-commonjs": "^14",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",


### PR DESCRIPTION
As the `classCallCheck` helper is used in `dist/cjs`, we should either get rid of it, or require `@babel/runtime` in dependencies.

Fixes #22 